### PR TITLE
bump gusty to 0.5.0

### DIFF
--- a/airflow/requirements.txt
+++ b/airflow/requirements.txt
@@ -48,7 +48,7 @@ Flask-WTF==0.14.3
 funcsigs==1.0.2
 graphviz==0.15
 gunicorn==19.10.0
-gusty==0.3.3
+gusty==0.5.0
 idna==2.10
 importlib-resources==1.5.0
 inflection==0.5.1


### PR DESCRIPTION
This will get rid of the annoying gusty bug in the prototype DAG where recursive folders are not ignored by `ignore_subfolders`. Additionally [.py task files](https://github.com/chriscardillo/gusty/releases/tag/v0.5.0) will now be supported.