### PR TITLE
Put github and slack into separate schemas for #27

### DIFF
--- a/airflow/demo-setup/datawarehouse_setup.py
+++ b/airflow/demo-setup/datawarehouse_setup.py
@@ -16,3 +16,17 @@ if not engine.dialect.has_schema(engine, 'views'):
     engine.execute("GRANT ALL PRIVILEGES ON SCHEMA views TO {user};".format(user = engine.url.username))
     engine.execute("GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA views TO {user};".format(user = engine.url.username))
     engine.execute("ALTER DEFAULT PRIVILEGES IN SCHEMA views GRANT ALL PRIVILEGES ON TABLES TO {user};".format(user = engine.url.username))
+
+# separate schema for github
+if not engine.dialect.has_schema(engine, 'views_github'):
+    engine.execute(sqlalchemy.schema.CreateSchema('views_github'))
+    engine.execute("GRANT ALL PRIVILEGES ON SCHEMA views_github TO {user};".format(user = engine.url.username))
+    engine.execute("GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA views_github TO {user};".format(user = engine.url.username))
+    engine.execute("ALTER DEFAULT PRIVILEGES IN SCHEMA views_github GRANT ALL PRIVILEGES ON TABLES TO {user};".format(user = engine.url.username))
+
+# separate schema for slack
+if not engine.dialect.has_schema(engine, 'views_slack'):
+    engine.execute(sqlalchemy.schema.CreateSchema('views_slack'))
+    engine.execute("GRANT ALL PRIVILEGES ON SCHEMA views_slack TO {user};".format(user = engine.url.username))
+    engine.execute("GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA views_slack TO {user};".format(user = engine.url.username))
+    engine.execute("ALTER DEFAULT PRIVILEGES IN SCHEMA views_slack GRANT ALL PRIVILEGES ON TABLES TO {user};".format(user = engine.url.username))

--- a/airflow/demo-setup/datawarehouse_setup.py
+++ b/airflow/demo-setup/datawarehouse_setup.py
@@ -18,15 +18,15 @@ if not engine.dialect.has_schema(engine, 'views'):
     engine.execute("ALTER DEFAULT PRIVILEGES IN SCHEMA views GRANT ALL PRIVILEGES ON TABLES TO {user};".format(user = engine.url.username))
 
 # separate schema for github
-if not engine.dialect.has_schema(engine, 'views_github'):
-    engine.execute(sqlalchemy.schema.CreateSchema('views_github'))
-    engine.execute("GRANT ALL PRIVILEGES ON SCHEMA views_github TO {user};".format(user = engine.url.username))
-    engine.execute("GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA views_github TO {user};".format(user = engine.url.username))
-    engine.execute("ALTER DEFAULT PRIVILEGES IN SCHEMA views_github GRANT ALL PRIVILEGES ON TABLES TO {user};".format(user = engine.url.username))
+if not engine.dialect.has_schema(engine, 'tap_github'):
+    engine.execute(sqlalchemy.schema.CreateSchema('tap_github'))
+    engine.execute("GRANT ALL PRIVILEGES ON SCHEMA tap_github TO {user};".format(user = engine.url.username))
+    engine.execute("GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA tap_github TO {user};".format(user = engine.url.username))
+    engine.execute("ALTER DEFAULT PRIVILEGES IN SCHEMA tap_github GRANT ALL PRIVILEGES ON TABLES TO {user};".format(user = engine.url.username))
 
 # separate schema for slack
-if not engine.dialect.has_schema(engine, 'views_slack'):
-    engine.execute(sqlalchemy.schema.CreateSchema('views_slack'))
-    engine.execute("GRANT ALL PRIVILEGES ON SCHEMA views_slack TO {user};".format(user = engine.url.username))
-    engine.execute("GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA views_slack TO {user};".format(user = engine.url.username))
-    engine.execute("ALTER DEFAULT PRIVILEGES IN SCHEMA views_slack GRANT ALL PRIVILEGES ON TABLES TO {user};".format(user = engine.url.username))
+if not engine.dialect.has_schema(engine, 'tap_slack'):
+    engine.execute(sqlalchemy.schema.CreateSchema('tap_slack'))
+    engine.execute("GRANT ALL PRIVILEGES ON SCHEMA tap_slack TO {user};".format(user = engine.url.username))
+    engine.execute("GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA tap_slack TO {user};".format(user = engine.url.username))
+    engine.execute("ALTER DEFAULT PRIVILEGES IN SCHEMA tap_slack GRANT ALL PRIVILEGES ON TABLES TO {user};".format(user = engine.url.username))

--- a/meltano/cfp-pipeline/meltano.yml
+++ b/meltano/cfp-pipeline/meltano.yml
@@ -44,16 +44,24 @@ plugins:
       postgres_username: $DEFAULT_USER
       postgres_password: $DEFAULT_PASSWORD
       postgres_schema: views
+  - name: target-postgres-github
+    inherit_from: target-postgres
+    config:
+      postgres_schema: views_github
+  - name: target-postgres-slack
+    inherit_from: target-postgres
+    config:
+      postgres_schema: views_slack
 schedules:
 - name: slack-to-postgres
   extractor: tap-slack
-  loader: target-postgres
+  loader: target-postgres-slack
   transform: skip
   interval: '@daily'
   start_date: 2021-01-08 00:00:00
 - name: github-to-postgres
   extractor: tap-github
-  loader: target-postgres
+  loader: target-postgres-github
   transform: skip
   interval: '@daily'
   start_date: 2021-01-15 18:41:47.984720

--- a/meltano/cfp-pipeline/meltano.yml
+++ b/meltano/cfp-pipeline/meltano.yml
@@ -47,11 +47,11 @@ plugins:
   - name: target-postgres-github
     inherit_from: target-postgres
     config:
-      postgres_schema: views_github
+      postgres_schema: tap_github
   - name: target-postgres-slack
     inherit_from: target-postgres
     config:
-      postgres_schema: views_slack
+      postgres_schema: tap_slack
 schedules:
 - name: slack-to-postgres
   extractor: tap-slack


### PR DESCRIPTION
For #27 puts tap_github into views_github and tap-slack into views_slack

For example:

```sql
datawarehouse=# \dt views_github.*
                 List of relations
    Schema    |       Name       | Type  |  Owner   
--------------+------------------+-------+----------
 views_github | assignees        | table | postgres
 views_github | collaborators    | table | postgres
 views_github | contributors     | table | postgres
 views_github | issue_labels     | table | postgres
 views_github | languages        | table | postgres
 views_github | repository       | table | postgres
 views_github | stargazers       | table | postgres
 views_github | team_members     | table | postgres
 views_github | team_memberships | table | postgres
 views_github | teams            | table | postgres
(10 rows)
```