### PR TITLE
Update meltano.yml

### DIFF
--- a/meltano/cfp-pipeline/meltano.yml
+++ b/meltano/cfp-pipeline/meltano.yml
@@ -40,6 +40,8 @@ plugins:
       private_channels: false
       join_public_channels: true
       exclude_archived: true
+    select:
+    - '!user_groups.*'
   loaders:
   - name: target-csv
     variant: singer-io


### PR DESCRIPTION
prevents slack tap from trying to pull the user groups data, which is not super common (and was throwing an error when uploading to target)